### PR TITLE
Update warning_types.py

### DIFF
--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -57,4 +57,4 @@ class UnformattedWarning(object):
         return self.category(self.template.format(**kwargs))
 
 
-PYTESTER_COPY_EXAMPLE = PytestExperimentalApiWarning.simple("testdir.copy_example")
+PYTESTER_COPY_EXAMPLE = PytestExperimentalApiWarning.simple("testdir.copy_example") #定义位置


### PR DESCRIPTION
使用位置:src/_pytest/pytester.py
         from _pytest.warning_types import PYTESTER_COPY_EXAMPLE
 60 PYTESTER_COPY_EXAMPLE = PytestExperimentalApiWarning.simple("testdir.copy_example")


