### PR TITLE
Update warning_types.py

### DIFF
--- a/src/_pytest/warning_types.py
+++ b/src/_pytest/warning_types.py
@@ -33,7 +33,7 @@ class PytestExperimentalApiWarning(PytestWarning, FutureWarning):
     removed completely in future version
     """
 
-    @classmethod
+    @classmethod #?
     def simple(cls, apiname):
         return cls(
             "{apiname} is an experimental api that may change over time".format(


### PR DESCRIPTION
1. \@ \ classmethod 的含义 
2.  PytestExperimentalApiWarning.simple("testdir.copy_example") 这里为什么只有1个参数，声明定义中不是两个吗?


